### PR TITLE
edit telegram log to normal file log

### DIFF
--- a/Fm_Ilbe_Dogdrip/dog_drip.py
+++ b/Fm_Ilbe_Dogdrip/dog_drip.py
@@ -194,9 +194,8 @@ def collect_dog_drip_document_content(keyword):
                         comments = page_result.find('div.comment-list > div.comment-item > div.comment-content > '
                                                     'div > div:nth-of-type(2) > div.xe_content')
                         if len(comments) == 0:
-                            # Send Telegram if no comments
-                            bot.sendMessage(chat_id=CHAT_ID,
-                                            text=f'link_id: {link[24:]} comment empty')
+                            # Save log if no comments
+                            print(f'link_id: {link[24:]} comment empty')
                             continue
                         else:
                             for comment in comments:

--- a/Fm_Ilbe_Dogdrip/dog_drip_normal.py
+++ b/Fm_Ilbe_Dogdrip/dog_drip_normal.py
@@ -194,9 +194,8 @@ def collect_dog_drip_document_content():
                         comments = page_result.find('div.comment-list > div.comment-item > div.comment-content > '
                                                     'div > div:nth-of-type(2) > div.xe_content')
                         if len(comments) == 0:
-                            # Send Telegram if no comments
-                            bot.sendMessage(chat_id=CHAT_ID,
-                                            text=f'link_id: {link[24:]} comment empty')
+                            # Save log if no comments
+                            print(f'link_id: {link[24:]} comment empty')
                             continue
                         else:
                             for comment in comments:

--- a/Fm_Ilbe_Dogdrip/fm_korea.py
+++ b/Fm_Ilbe_Dogdrip/fm_korea.py
@@ -186,9 +186,9 @@ def collect_fm_korea_document_content(keyword, start_page, end_page):
                     # Comment text
                     comments = page_result.find('ul.fdb_lst_ul > li > div:nth-of-type(2) > div.xe_content')
                     if len(comments) == 0:
-                        # Send Telegram if the content is None
-                        bot.sendMessage(chat_id=CHAT_ID,
-                                        text=f'link_id: {link[24:]} comment empty')
+                        # Save log if the content is None
+                        print(f'link_id: {link[24:]} comment empty')
+                        continue
                     for comment in comments:
                         # Replace line change into blank
                         comment_content = comment.text.replace("\n", " ")

--- a/Fm_Ilbe_Dogdrip/ilbe.py
+++ b/Fm_Ilbe_Dogdrip/ilbe.py
@@ -232,9 +232,8 @@ def collect_ilbe_document_content(keyword):
                             'div.xe_content'
                         )
                         if len(comments) == 0:
-                            # Send Telegram if no comments
-                            bot.sendMessage(chat_id=CHAT_ID,
-                                            text=f'link_id: {link[24:]} comment empty')
+                            # Save log if no comments
+                            print(f'link_id: {link[24:]} comment empty')
                             continue
                         else:
                             for comment in comments:


### PR DESCRIPTION
댓글이 비어 있을 경우 텔레그램 로그로 보내는 대신 `nohup.out`에 출력될 수 있도록 변경
